### PR TITLE
Fix for incorrect mean AP

### DIFF
--- a/src/torchmetrics/detection/mean_ap.py
+++ b/src/torchmetrics/detection/mean_ap.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+import sys
+
+sys.path.append("/Users/dhananjaisharma/projects/metrics/src")
 
 import numpy as np
 import torch
@@ -642,7 +645,7 @@ class MeanAveragePrecision(Metric):
             thr:
                 Current threshold value.
             gt_matches:
-                Tensor showing if a ground truth matches for threshold ``t`` exists.
+                Tensor showing if a ground truth matches for threshold ``thr`` exists.
             gt_ignore:
                 Tensor showing if ground truth should be ignored.
             ious:
@@ -724,6 +727,19 @@ class MeanAveragePrecision(Metric):
             for area in area_ranges
             for img_id in img_ids
         ]
+
+        """
+        First entry in `eval_imgs` for each class.
+
+        (Pdb) eval_imgs[0 * len(img_ids) * len(area_ranges)]
+        {'dtMatches': tensor([[True]]), 'gtMatches': tensor([[True]]), 'dtScores': tensor([0.6000]), 'gtIgnore': tensor([False]), 'dtIgnore': tensor([[False]])}
+        (Pdb) eval_imgs[1 * len(img_ids) * len(area_ranges)]
+        {'dtMatches': tensor([[True]]), 'gtMatches': tensor([[True]]), 'dtScores': tensor([0.6000]), 'gtIgnore': tensor([False]), 'dtIgnore': tensor([[False]])}
+        (Pdb) eval_imgs[2 * len(img_ids) * len(area_ranges)]
+        {'dtMatches': tensor([[False]]), 'gtMatches': tensor([], size=(1, 0), dtype=torch.bool), 'dtScores': tensor([0.6000]), 'gtIgnore': tensor([], dtype=torch.bool), 'dtIgnore': tensor([[False]])}
+        (Pdb) eval_imgs[3 * len(img_ids) * len(area_ranges)]
+        {'dtMatches': tensor([[False]]), 'gtMatches': tensor([], size=(1, 0), dtype=torch.bool), 'dtScores': tensor([0.6000]), 'gtIgnore': tensor([], dtype=torch.bool), 'dtIgnore': tensor([[False]])}
+        """
 
         nb_iou_thrs = len(self.iou_thresholds)
         nb_rec_thrs = len(self.rec_thresholds)
@@ -825,12 +841,30 @@ class MeanAveragePrecision(Metric):
         inds = torch.argsort(det_scores.to(dtype), descending=True)
         det_scores_sorted = det_scores[inds]
 
-        det_matches = torch.cat([e["dtMatches"][:, :max_det] for e in img_eval_cls_bbox], axis=1)[:, inds]
-        det_ignore = torch.cat([e["dtIgnore"][:, :max_det] for e in img_eval_cls_bbox], axis=1)[:, inds]
+        # TODO: Move this code earlier than det_scores.
         gt_ignore = torch.cat([e["gtIgnore"] for e in img_eval_cls_bbox])
         npig = torch.count_nonzero(gt_ignore == False)  # noqa: E712
         if npig == 0:
+            # TODO: Need to find a proper way to assign something here.
+            there_are_predictions = True
+
+            # If there are predictions made for this class, then mark precision
+            # as 0. Otherwise, keep it 1.
+            if there_are_predictions:
+                # TODO: Unsure about what to put in the first index.
+                precision[:, :, idx_cls, idx_bbox_area, idx_max_det_thrs] = 0.
+            else:
+                # TODO: Unsure about what to put in the first index.
+                precision[:, :, idx_cls, idx_bbox_area, idx_max_det_thrs] = 1.
+
+            # TODO: Handle recall as well.
+            # Since there is no GT, the Recall will also become zero. We can
+            # also keep it as -1 to convey that it is an undefined value.
+
             return recall, precision, scores
+
+        det_matches = torch.cat([e["dtMatches"][:, :max_det] for e in img_eval_cls_bbox], axis=1)[:, inds]
+        det_ignore = torch.cat([e["dtIgnore"][:, :max_det] for e in img_eval_cls_bbox], axis=1)[:, inds]
         tps = torch.logical_and(det_matches, torch.logical_not(det_ignore))
         fps = torch.logical_and(torch.logical_not(det_matches), torch.logical_not(det_ignore))
 
@@ -919,3 +953,29 @@ class MeanAveragePrecision(Metric):
         metrics[f"mar_{self.max_detection_thresholds[-1]}_per_class"] = mar_max_dets_per_class_values
 
         return metrics
+
+
+if __name__ == "__main__":
+    metric = MeanAveragePrecision(iou_thresholds=[0.5], class_metrics=True)
+    preds = [
+        dict(
+            boxes=torch.Tensor([[0, 0, 20, 20],  # TP for class 0
+                                [30, 30, 50, 50],  # TP for class 1
+                                [70, 70, 90, 90],  # FP for class 2
+                                [100, 100, 120, 120]]),  # FP for class 3
+            scores=torch.Tensor([0.6, 0.6, 0.6, 0.6]),
+            labels=torch.IntTensor([0, 1, 2, 3]),
+        )
+    ]
+
+    targets = [
+        dict(
+            boxes=torch.Tensor([[0, 0, 20, 20],
+                                [30, 30, 50, 50]]),
+            labels=torch.IntTensor([0, 1]),
+        )
+    ]
+    metric.update(preds, targets)
+
+    from pprint import pprint
+    pprint(metric.compute())


### PR DESCRIPTION
## What does this PR do?

Fixes #1184

Adds a fix for incorrect mean AP when there are no GT bboxes for a class, but there are predicted boxes. This can happen in the following cases:
- When all GT boxes are to be ignored.
- When there are no GT boxes.

**Solution**: Make Precision for that class `0`.

**Note**: I am yet to write tests. I tried running them at `tests/unittests/detection/test_map.py` but faced a `FileNotFoundError` exception because of the following missing file: `_SAMPLE_DETECTION_SEGMENTATION = os.path.join(_PATH_ROOT, "_data", "detection", "instance_segmentation_inputs.json")`

Please check the code inside the issue and check the before vs. after outputs below.

### Before
```python
{'map': tensor(1.),
 'map_50': tensor(1.),
 'map_75': tensor(-1),
 'map_large': tensor(-1.),
 'map_medium': tensor(-1.),
 'map_per_class': tensor([ 1.,  1., -1., -1.]),
 'map_small': tensor(1.),
 'mar_1': tensor(1.),
 'mar_10': tensor(1.),
 'mar_100': tensor(1.),
 'mar_100_per_class': tensor([ 1.,  1., -1., -1.]),
 'mar_large': tensor(-1.),
 'mar_medium': tensor(-1.),
 'mar_small': tensor(1.)}
```
### After
```python
{'map': tensor(0.5000),
 'map_50': tensor(0.5000),
 'map_75': tensor(-1),
 'map_large': tensor(0.),
 'map_medium': tensor(0.),
 'map_per_class': tensor([1., 1., 0., 0.]),
 'map_small': tensor(0.5000),
 'mar_1': tensor(1.),
 'mar_10': tensor(1.),
 'mar_100': tensor(1.),
 'mar_100_per_class': tensor([ 1.,  1., -1., -1.]),
 'mar_large': tensor(-1.),
 'mar_medium': tensor(-1.),
 'mar_small': tensor(1.)}
```

Other changes:
- Moved up the code for checking `gtignore` to early-return from the function. This will save computation.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
